### PR TITLE
[codex] Evaluate RT-DETR outputs and SAMURAI settings in E2E

### DIFF
--- a/e2e/compose.phase4.yml
+++ b/e2e/compose.phase4.yml
@@ -18,6 +18,12 @@ x-backend-env: &backend-env
   <<: [*surreal-env, *s3-env]
   POLL_INTERVAL: "5"
   KEEP_WORK_DIR: "0"
+  RTDETR_BASE_MODEL: "rtdetr-l.pt"
+  RTDETR_PRETRAINED: "1"
+  RTDETR_EPOCHS: "12"
+  RTDETR_IMGSZ: "640"
+  RTDETR_INFER_CONF: "0.25"
+  RTDETR_EXPORT_TRT: "0"
 
 x-build-gpu: &build-gpu
   context: ../../mlops-cloud-backend
@@ -124,5 +130,5 @@ services:
       - -lc
       - |
           set -eu
-          uv pip install pytest
+          uv pip install pytest pandas pyarrow
           uv run pytest -q tests_phase4

--- a/e2e/phase4/test_gpu_samurai_pipeline.py
+++ b/e2e/phase4/test_gpu_samurai_pipeline.py
@@ -1,7 +1,9 @@
 import os
+import tempfile
 import time
 from pathlib import Path
 
+import pandas as pd
 import pytest
 import requests
 
@@ -29,6 +31,41 @@ def _wait_for(predicate, *, timeout: int, interval: int = 10, label: str):
             return last
         time.sleep(interval)
     raise AssertionError(f"Timed out waiting for {label}; last={last!r}")
+
+
+def _meta(row: dict) -> dict:
+    meta = row.get("meta")
+    return meta if isinstance(meta, dict) else {}
+
+
+def _artifact_description(row: dict) -> str:
+    return str(_meta(row).get("description") or "")
+
+
+def _download_parquet(s3, key: str) -> pd.DataFrame:
+    with tempfile.NamedTemporaryFile(suffix=".parquet") as tmp:
+        s3.s3.download_file(s3.bucket, key, tmp.name)
+        return pd.read_parquet(tmp.name)
+
+
+def _assert_bbox_rows(
+    df: pd.DataFrame,
+    *,
+    label: str,
+    source: str,
+    min_positive_ratio: float = 0.95,
+) -> None:
+    assert not df.empty, f"{source} parquet must contain at least one detection row"
+    for column in ["frame_index", "label", "x", "y", "w", "h"]:
+        assert column in df.columns, f"{source} parquet is missing column: {column}"
+    assert set(df["label"].dropna().astype(str)) == {label}
+    assert (df["frame_index"].astype(int) >= 0).all()
+    positive_bbox = (df["w"].astype(float) > 0) & (df["h"].astype(float) > 0)
+    assert positive_bbox.any(), f"{source} parquet has no positive-size bbox rows"
+    assert positive_bbox.mean() >= min_positive_ratio, (
+        f"{source} positive bbox ratio is too low: "
+        f"{positive_bbox.mean():.3f} < {min_positive_ratio:.3f}"
+    )
 
 
 def test_real_samurai_ulr_gpu_pipeline_to_hls_and_ui(db, s3, fixture_video: Path):
@@ -115,16 +152,43 @@ def test_real_samurai_ulr_gpu_pipeline_to_hls_and_ui(db, s3, fixture_video: Path
         assert steps.get(key) == "completed"
 
     results = _rows(db, "SELECT * FROM inference_result WHERE job = <record> $JOB;", {"JOB": job_id})
-    artifacts = {((r.get("meta") or {}).get("artifact")): r for r in results}
-    assert "plot_video" in artifacts
-    assert "results_parquet" in artifacts
+    artifact_names = {str(_meta(r).get("artifact")) for r in results}
+    assert "plot_video" in artifact_names
+    assert "results_parquet" in artifact_names
     if require_schema_json:
-        assert "schema_json" in artifacts
+        assert "schema_json" in artifact_names
 
     for result in results:
         assert object_exists(s3, result["key"]) is True
 
-    plot_result_id = str(artifacts["plot_video"]["id"])
+    sam2_parquets = [
+        r for r in results
+        if _meta(r).get("artifact") == "results_parquet"
+        and "SAM2" in _artifact_description(r)
+    ]
+    assert sam2_parquets, f"SAM2 results parquet was not registered: {results!r}"
+    sam2_df = _download_parquet(s3, sam2_parquets[0]["key"])
+    _assert_bbox_rows(sam2_df, label="object", source="SAM2", min_positive_ratio=0.90)
+
+    rtdetr_parquets = [
+        r for r in results
+        if _meta(r).get("artifact") == "results_parquet"
+        and "最終推論結果" in _artifact_description(r)
+    ]
+    assert rtdetr_parquets, f"RT-DETR final parquet was not registered: {results!r}"
+    rtdetr_df = _download_parquet(s3, rtdetr_parquets[0]["key"])
+    _assert_bbox_rows(rtdetr_df, label="object", source="RT-DETR", min_positive_ratio=0.90)
+    assert "conf" in rtdetr_df.columns
+    assert rtdetr_df["conf"].notna().all()
+    assert (rtdetr_df["conf"].astype(float) >= 0).all()
+
+    rtdetr_plot_videos = [
+        r for r in results
+        if _meta(r).get("artifact") == "plot_video"
+        and "RT-DETR" in _artifact_description(r)
+    ]
+    assert rtdetr_plot_videos, f"RT-DETR plot video was not registered: {results!r}"
+    plot_result_id = str(rtdetr_plot_videos[0]["id"])
 
     def hls_ready():
         playlists = _rows(db, "SELECT * FROM hls_playlist WHERE file = <record> $FILE;", {"FILE": plot_result_id})

--- a/e2e/phase4/test_gpu_samurai_pipeline.py
+++ b/e2e/phase4/test_gpu_samurai_pipeline.py
@@ -130,6 +130,8 @@ def test_real_samurai_ulr_gpu_pipeline_to_hls_and_ui(db, s3, fixture_video: Path
                 taskType: 'one-shot-object-detection',
                 model: 'samurai-ulr',
                 modelSource: 'internet',
+                inferenceBackend: 'pytorch-fp32',
+                rtdetrEpochs: 4,
                 datasets: [$DATASET],
                 createdAt: time::now(),
                 updatedAt: time::now()

--- a/e2e/tests/inference.spec.ts
+++ b/e2e/tests/inference.spec.ts
@@ -43,6 +43,8 @@ test("creates an inference job from a seeded video dataset", async ({ page }) =>
     taskType: "one-shot-object-detection",
     model: "samurai-ulr",
     modelSource: "internet",
+    inferenceBackend: "tensorrt-fp16",
+    rtdetrEpochs: 4,
     datasets: [dataset],
   });
 });


### PR DESCRIPTION
## Summary
- Extends Phase4 E2E to validate registered SAM2 and final RT-DETR parquet outputs, not only job completion and HLS availability.
- Configures Phase4 to run SAMURAI ULR through explicit `inferenceBackend: 'pytorch-fp32'` and `rtdetrEpochs: 4` job settings.
- Extends UI E2E expectations to verify default `inferenceBackend: 'tensorrt-fp16'` and `rtdetrEpochs: 4` are persisted.

## Why
The previous Phase4 coverage could pass even when RT-DETR final inference produced an empty parquet. The UI/backend now expose per-job backend and epoch settings, so E2E needs to assert those defaults and use the stable PyTorch path for real GPU validation.

## Validation
- `docker compose -p phase4-rtdetr-b -f e2e/compose.phase4.yml -f /tmp/mlops-phase4-no-ports.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test`
- Result: `1 passed in 166.02s`
- `docker compose -p phase1-inference-epochs -f e2e/compose.phase1.yml up --build --abort-on-container-exit --exit-code-from e2e e2e`
- Result: `6 passed, 3 skipped`
