### PR TITLE
[codex] Update compose and E2E docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+このリポジトリは MLOps Cloud の統合 compose と E2E テストを管理します。UI / backend の実装本体は兄弟リポジトリ `../mlops-cloud-ui` と `../mlops-cloud-backend` にあります。
+
+## 責務
+
+- 本番寄り compose: `docker-compose.yml`
+- 開発 compose: `docker-compose.dev.yml`
+- E2E compose / tests: `e2e/`
+- リリース時の統合入口
+
+## 開発 compose
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+GPU worker も使う場合:
+
+```bash
+docker compose -f docker-compose.dev.yml --profile gpu up --build
+```
+
+停止:
+
+```bash
+docker compose -f docker-compose.dev.yml down
+```
+
+開発 compose の特徴:
+
+- `../mlops-cloud-ui` と `../mlops-cloud-backend` を mount します。
+- `cloud-ui` は Dockerfile から build し、`npm run dev` で起動します。
+- backend は `Dockerfile.base` / `Dockerfile.gpu` から build します。
+- SurrealDB は `memory`、MinIO は `tmpfs` です。起動ごとに DB/S3 はリセットされます。
+- `mlx-backend` / `cv-backend` は GPU profile です。
+
+## E2E
+
+E2E は全て `e2e/` に集約します。UI repo や backend repo に分散させないでください。
+
+Phase1 UI:
+
+```bash
+docker compose -f e2e/compose.phase1.yml up --build --abort-on-container-exit --exit-code-from e2e e2e
+docker compose -f e2e/compose.phase1.yml down -v
+```
+
+Phase2 backend integration:
+
+```bash
+docker compose -f e2e/compose.phase2.yml up --build --abort-on-container-exit --exit-code-from backend-test backend-test
+docker compose -f e2e/compose.phase2.yml down -v
+```
+
+Phase3 system smoke:
+
+```bash
+docker compose -f e2e/compose.phase3.yml up --build --abort-on-container-exit --exit-code-from system-e2e system-e2e
+docker compose -f e2e/compose.phase3.yml down -v
+```
+
+Phase4 GPU pipeline:
+
+```bash
+docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test
+docker compose -f e2e/compose.phase4.yml down -v
+```
+
+Phase4 は NVIDIA container runtime と十分な GPU リソースが必要です。PRごとの必須テストにはしません。
+
+## 現在の期待値
+
+- Phase1: `6 passed, 3 skipped`
+- Phase2: skip なし
+- Phase3: skip なし
+- Phase4: skip なし。ただし GPU 環境依存
+
+Phase1 の skip は未実装ではなく、仕様未確定箇所を `test.fixme` で明示したものです。
+
+## Docker image 方針
+
+- MLOps Cloud app image はローカル Dockerfile から build します。
+- SurrealDB / MinIO / Playwright base image は pull で構いません。
+- 古い `Dockerfile.cv` / `Dockerfile.mlx` 参照を追加しないでください。現在は `Dockerfile.base` / `Dockerfile.gpu` です。
+
+## 作業ルール
+
+- main へ直接 commit しないでください。
+- compose サービス名、env、E2E 実行手順を変更した場合は `README.md`, `e2e/README.md`, ワークスペース直下の `E2E_TEST_RUNBOOK.md` も更新してください。
+- E2E 実行後は必ず `down -v` で片付けてください。

--- a/README.md
+++ b/README.md
@@ -1,30 +1,33 @@
 # MLOps Cloud
 
+MLOps Cloud の統合 compose / E2E リポジトリです。アプリ本体の実装は兄弟リポジトリにあります。
+
+| Path | Role |
+|---|---|
+| `../mlops-cloud-ui` | Next.js UI and API routes |
+| `../mlops-cloud-backend` | Python workers for HLS, inference, cleaner, metrics, terminal |
+| `../mlops-cloud-updater` | Release/update helper |
+| `e2e/` | Compose-based E2E tests |
+
 ## Development Compose
 
-`docker-compose.dev.yml` はローカル開発向けの構成です。
+`docker-compose.dev.yml` はローカル開発向けです。
 
-- `../mlops-cloud-ui` と `../mlops-cloud-backend` をコンテナへマウント
-- `mlops-cloud-*` 系サービス（UI/Backend）はローカルの Dockerfile から build
-- `surrealdb` / `minio` は通常どおり pull
-- SurrealDB は `memory` モードで起動
-- MinIO は `tmpfs` (`/data`) を使って起動
-- `cloud-ui` は `npm run dev` で起動（TTY + stdin open）
-
-上記により、DB/Object Storage のデータはコンテナ起動ごとにリセットされます。
-
-## 起動方法
-
-`mlops-cloud` ディレクトリで実行:
+- UI/backend source をコンテナへ mount
+- MLOps Cloud app images はローカル Dockerfile から build
+- SurrealDB は `memory`
+- MinIO は `tmpfs`
+- 起動ごとに DB/Object Storage はリセット
+- UI は `npm run dev` で起動し、TTY/stdin を有効化
 
 ```bash
-docker compose -f docker-compose.dev.yml up
+docker compose -f docker-compose.dev.yml up --build
 ```
 
-GPU ワーカー (`mlx-backend`, `cv-backend`) も起動する場合:
+GPU worker も起動する場合:
 
 ```bash
-docker compose -f docker-compose.dev.yml --profile gpu up
+docker compose -f docker-compose.dev.yml --profile gpu up --build
 ```
 
 停止:
@@ -33,12 +36,68 @@ docker compose -f docker-compose.dev.yml --profile gpu up
 docker compose -f docker-compose.dev.yml down
 ```
 
-## Phase 1 E2E
+## Service URLs
 
-UI E2E tests live in `e2e/`.
+| URL | Service |
+|---|---|
+| http://localhost:3000 | cloud-ui |
+| http://localhost:8000 | SurrealDB |
+| http://localhost:9000 | MinIO S3 API |
+| http://localhost:9001 | MinIO Console |
+| ws://localhost:8765 | terminal-manager |
+
+Default local credentials:
+
+- SurrealDB: `root` / `root`, namespace `mlops`, database `cloud_ui`
+- MinIO: `minioadmin` / `minioadmin`, bucket `mlops-datasets`
+
+## E2E
+
+All E2E lives under `e2e/`. See `../E2E_TEST_RUNBOOK.md` for detailed operation notes.
+
+Phase1 UI:
 
 ```bash
 docker compose -f e2e/compose.phase1.yml up --build --abort-on-container-exit --exit-code-from e2e e2e
+docker compose -f e2e/compose.phase1.yml down -v
 ```
 
-The E2E compose builds `cloud-ui` from `../mlops-cloud-ui/Dockerfile` and builds the test runner from `e2e/Dockerfile`. SurrealDB and MinIO use disposable in-memory/tmpfs storage.
+Phase2 backend integration:
+
+```bash
+docker compose -f e2e/compose.phase2.yml up --build --abort-on-container-exit --exit-code-from backend-test backend-test
+docker compose -f e2e/compose.phase2.yml down -v
+```
+
+Phase3 system smoke:
+
+```bash
+docker compose -f e2e/compose.phase3.yml up --build --abort-on-container-exit --exit-code-from system-e2e system-e2e
+docker compose -f e2e/compose.phase3.yml down -v
+```
+
+Phase4 GPU pipeline:
+
+```bash
+docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test
+docker compose -f e2e/compose.phase4.yml down -v
+```
+
+Phase4 requires NVIDIA container runtime and a compatible GPU.
+
+## Current E2E Notes
+
+- Phase1 currently reports `6 passed, 3 skipped`.
+- Skipped Phase1 tests are `test.fixme` for unsettled UI/training constraints:
+  - multiple dataset inference rejection
+  - dataset video count rejection
+  - training creation disabled/preview without a worker
+- Security tests for `/api/db/query` run and should pass.
+- Phase2/3/4 are expected to have no skips when their environment requirements are met.
+
+## Image Policy
+
+- `cloud-ui` builds from `../mlops-cloud-ui/Dockerfile`.
+- backend base services build from `../mlops-cloud-backend/Dockerfile.base`.
+- GPU services build from `../mlops-cloud-backend/Dockerfile.gpu`.
+- SurrealDB / MinIO / Playwright base images are pulled.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,22 +1,40 @@
 # MLOps Cloud E2E
 
-This directory contains all implemented test phases from `../../E2E_TEST_PLAN.md`.
+This directory contains compose-based E2E tests for the multi-repository development workspace.
 
-All MLOps Cloud app images are built from local Dockerfiles. SurrealDB and MinIO are service dependencies and are pulled as base services. SurrealDB uses `memory`; MinIO uses `tmpfs`, so DB and object-storage state reset with each compose run.
+All MLOps Cloud app images are built from local Dockerfiles. SurrealDB, MinIO, and Playwright base images are pulled dependencies. SurrealDB uses `memory`; MinIO uses `tmpfs`, so DB and object-storage state reset with each compose run.
 
 Fixtures are stored in `fixtures/`:
 
-- `test-image.jpeg` is used for image upload and object preview tests.
-- `test-video.mp4` is used for seeded video inference job tests.
+- `test-image.jpeg`: image upload and object preview tests.
+- `test-video.mp4`: seeded video inference and GPU pipeline tests.
+
+Always run commands from the `mlops-cloud` repository root.
 
 ## Phase 1 UI E2E
 
-Builds `cloud-ui` from `../../mlops-cloud-ui/Dockerfile` and runs Playwright against UI flows.
+Builds `cloud-ui` from `../../mlops-cloud-ui/Dockerfile` and runs Playwright against UI/API flows.
 
 ```bash
 docker compose -f e2e/compose.phase1.yml up --build --abort-on-container-exit --exit-code-from e2e e2e
 docker compose -f e2e/compose.phase1.yml down -v
 ```
+
+Current expected result: `6 passed, 3 skipped`.
+
+Executed tests include:
+
+- `/api/status` health
+- dataset upload and object detail
+- dataset/object soft delete
+- inference job creation from a seeded video dataset
+- `/api/db/query` security allowlist behavior
+
+Skipped tests are `test.fixme` for unsettled product behavior:
+
+- inference creation rejects multiple selected datasets with a visible reason
+- inference creation rejects datasets without exactly one video with a visible reason
+- training creation is disabled or marked preview while no training worker exists
 
 ## Phase 2 Backend Integration
 
@@ -27,7 +45,7 @@ docker compose -f e2e/compose.phase2.yml up --build --abort-on-container-exit --
 docker compose -f e2e/compose.phase2.yml down -v
 ```
 
-Covered now:
+Covered areas:
 
 - env config loading and legacy fallback behavior
 - SurrealDB query helper extraction and record id handling
@@ -37,7 +55,7 @@ Covered now:
 
 ## Phase 3 System E2E
 
-Builds `cloud-ui` from `../../mlops-cloud-ui/Dockerfile`, starts SurrealDB and MinIO, and runs a system smoke against `/api/status`, `/`, `/dataset`, and `/inference`.
+Builds `cloud-ui`, starts SurrealDB and MinIO, and runs a smoke check against `/api/status`, `/`, `/dataset`, and `/inference`.
 
 ```bash
 docker compose -f e2e/compose.phase3.yml up --build --abort-on-container-exit --exit-code-from system-e2e system-e2e
@@ -49,20 +67,26 @@ docker compose -f e2e/compose.phase3.yml down -v
 Builds `mlx-backend` and `cv-backend` from `../../mlops-cloud-backend/Dockerfile.gpu`, seeds one video plus a SAM2 bbox annotation, runs the real `samurai-ulr` inference pipeline, and verifies:
 
 - `inference_job.status` reaches `Completed`
+- major progress steps complete
 - inference result video and parquet artifacts are registered in DB and exist in S3
-- the result video is HLS encoded by `cv-backend`
-- the inference UI pages return HTTP 200
+- result video is HLS encoded by `cv-backend`
+- HLS playlist and segments are registered and stored
+- inference UI pages return HTTP 200
 
-This is intended for manual/nightly/self-hosted GPU execution. It requires the NVIDIA container runtime and enough time for SAMURAI/RT-DETR processing.
+This is intended for manual/nightly/self-hosted GPU execution.
 
 ```bash
 docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test
 docker compose -f e2e/compose.phase4.yml down -v
 ```
 
-Optional environment overrides:
+Optional overrides:
 
 ```bash
 PHASE4_TIMEOUT_SECONDS=7200 docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test
 PHASE4_REQUIRE_SCHEMA_JSON=1 docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test
 ```
+
+## Cleanup
+
+Use `down -v` after each run to remove disposable DB/S3 state. This avoids carrying state between phases.


### PR DESCRIPTION
## Summary

- Add repository-level AGENTS guidance for compose and E2E work.
- Expand README with development compose, service URLs, image policy, and all E2E phases.
- Refresh `e2e/README.md` with current Phase1 expectations, skip reasons, and Phase4 GPU notes.

## Validation

- `git diff --check HEAD~1..HEAD`

## Notes

Documentation-only change.