### PR TITLE
[codex] Remove terminal service from compose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Phase4 は NVIDIA container runtime と十分な GPU リソースが必要です
 
 ## 現在の期待値
 
-- Phase1: `6 passed, 3 skipped`
+- Phase1: `7 passed, 3 skipped`
 - Phase2: skip なし
 - Phase3: skip なし
 - Phase4: skip なし。ただし GPU 環境依存

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MLOps Cloud の統合 compose / E2E リポジトリです。アプリ本体の�
 | Path | Role |
 |---|---|
 | `../mlops-cloud-ui` | Next.js UI and API routes |
-| `../mlops-cloud-backend` | Python workers for HLS, inference, cleaner, metrics, terminal |
+| `../mlops-cloud-backend` | Python workers for HLS, inference, cleaner, metrics |
 | `../mlops-cloud-updater` | Release/update helper |
 | `e2e/` | Compose-based E2E tests |
 
@@ -44,7 +44,6 @@ docker compose -f docker-compose.dev.yml down
 | http://localhost:8000 | SurrealDB |
 | http://localhost:9000 | MinIO S3 API |
 | http://localhost:9001 | MinIO Console |
-| ws://localhost:8765 | terminal-manager |
 
 Default local credentials:
 
@@ -87,7 +86,7 @@ Phase4 requires NVIDIA container runtime and a compatible GPU.
 
 ## Current E2E Notes
 
-- Phase1 currently reports `6 passed, 3 skipped`.
+- Phase1 currently reports `7 passed, 3 skipped`.
 - Skipped Phase1 tests are `test.fixme` for unsettled UI/training constraints:
   - multiple dataset inference rejection
   - dataset video count rejection

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,6 @@ x-backend-src-gpu: &backend-src-gpu
   - ../mlops-cloud-backend/ml_inference_manager.py:/workspace/src/ml_inference_manager.py
   - ../mlops-cloud-backend/cleaner_manager.py:/workspace/src/cleaner_manager.py
   - ../mlops-cloud-backend/hardware_metrics_manager.py:/workspace/src/hardware_metrics_manager.py
-  - ../mlops-cloud-backend/terminal_manager.py:/workspace/src/terminal_manager.py
 
 x-backend-src-base: &backend-src-base
   - ../mlops-cloud-backend/backend_module:/app/backend_module
@@ -36,7 +35,6 @@ x-backend-src-base: &backend-src-base
   - ../mlops-cloud-backend/ml_inference_manager.py:/app/ml_inference_manager.py
   - ../mlops-cloud-backend/cleaner_manager.py:/app/cleaner_manager.py
   - ../mlops-cloud-backend/hardware_metrics_manager.py:/app/hardware_metrics_manager.py
-  - ../mlops-cloud-backend/terminal_manager.py:/app/terminal_manager.py
 
 x-build-cloud-ui: &build-cloud-ui
   context: ../mlops-cloud-ui
@@ -188,23 +186,6 @@ services:
       <<: *backend-common-env
     volumes: *backend-src-base
     command: ["uv", "run", "/app/cleaner_manager.py"]
-    restart: unless-stopped
-
-  terminal-manager:
-    image: mlops-cloud-backend-base:dev
-    pull_policy: build
-    build: *build-backend-base
-    tty: true
-    depends_on:
-      - database
-      - object-storage
-    environment:
-      TERMINAL_WS_HOST: 0.0.0.0
-      TERMINAL_WS_PORT: "8765"
-    volumes: *backend-src-base
-    ports:
-      - "8765:8765"
-    command: ["uv", "run", "/app/terminal_manager.py"]
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,17 +160,6 @@ services:
     restart: unless-stopped
     command: ["uv", "run", "/app/cleaner_manager.py"]
 
-  terminal-manager:
-    image: taigatakano/mlops-cloud-backend-base:main
-    ports:
-      - "8765:8765"
-    tty: true
-    environment:
-      TERMINAL_WS_HOST: 0.0.0.0
-      TERMINAL_WS_PORT: "8765"
-    restart: unless-stopped
-    command: ["uv", "run", "/app/terminal_manager.py"]
-
 volumes:
   minio-data:
   surrealdb-data:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,7 +20,7 @@ docker compose -f e2e/compose.phase1.yml up --build --abort-on-container-exit --
 docker compose -f e2e/compose.phase1.yml down -v
 ```
 
-Current expected result: `6 passed, 3 skipped`.
+Current expected result: `7 passed, 3 skipped`.
 
 Executed tests include:
 
@@ -29,6 +29,7 @@ Executed tests include:
 - dataset/object soft delete
 - inference job creation from a seeded video dataset
 - `/api/db/query` security allowlist behavior
+- removed `/terminal` and `/docs*` routes are not exposed
 
 Skipped tests are `test.fixme` for unsettled product behavior:
 

--- a/e2e/tests/security.spec.ts
+++ b/e2e/tests/security.spec.ts
@@ -75,3 +75,16 @@ test("DB proxy only accepts allowlisted operations with validated input", async 
   });
   expect(allowed).toEqual({ status: 200, ok: true });
 });
+
+test("removed terminal and in-app docs routes are not exposed", async ({ page, request }) => {
+  await page.goto("/");
+  await expect(page).toHaveURL(/\/dataset$/);
+
+  await expect(page.getByRole("link", { name: /terminal/i })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /docs/i })).toHaveCount(0);
+
+  for (const path of ["/terminal", "/docs", "/docs/user", "/docs/developer"]) {
+    const response = await request.get(path);
+    expect(response.status(), `${path} should not be routable`).toBe(404);
+  }
+});


### PR DESCRIPTION
## Summary
- Remove `terminal-manager` from production and development compose files.
- Remove the `8765` host exposure and terminal source mounts.
- Add Phase1 E2E coverage that verifies removed terminal/docs routes are not exposed and `/` lands on `/dataset`.

## Impact
- Standard compose no longer exposes a WebSocket path to host SSH.
- Dataset becomes the default landing experience through the UI redirect.

## Validation
- `docker compose -f docker-compose.yml config`
- `docker compose -f docker-compose.dev.yml config`
- `docker compose -f docker-compose.dev.yml --profile gpu config --services`
- `git diff --check`
- Phase1 E2E: `7 passed, 3 skipped`
- Phase2 E2E: `15 passed`