### PR TITLE
[codex] Cover hardware metrics in E2E

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Phase4 requires NVIDIA container runtime and a compatible GPU.
   - dataset video count rejection
   - training creation disabled/preview without a worker
 - Security tests for `/api/db/query` run and should pass.
+- Phase3 checks CPU hardware metrics from `hm-backend`.
+- Phase4 checks GPU hardware metrics from GPU-enabled `hm-backend`.
 - Phase2/3/4 are expected to have no skips when their environment requirements are met.
 
 ## Image Policy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -164,12 +164,19 @@ services:
     image: mlops-cloud-backend-base:dev
     pull_policy: build
     build: *build-backend-base
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu", "utility"]
     shm_size: 32G
     depends_on:
       - database
       - object-storage
     environment:
       <<: *surreal-env
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: utility
     volumes: *backend-src-base
     command: ["uv", "run", "/app/hardware_metrics_manager.py"]
     restart: unless-stopped

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -53,10 +53,11 @@ Covered areas:
 - HLS and inference job status transitions
 - cleaner dead-file and orphan-annotation DB/S3 cleanup
 - inference runner validation for zero, multiple, no-video, multiple-video, and valid single-video dataset inputs
+- hardware metric CPU/GPU record shape, including a mocked NVML GPU
 
 ## Phase 3 System E2E
 
-Builds `cloud-ui`, starts SurrealDB and MinIO, and runs a smoke check against `/api/status`, `/`, `/dataset`, and `/inference`.
+Builds `cloud-ui` and the base backend image, starts SurrealDB, MinIO, and `hm-backend`, then checks `/api/status`, `/`, `/dataset`, `/inference`, and CPU hardware metrics in `hardware_metric`.
 
 ```bash
 docker compose -f e2e/compose.phase3.yml up --build --abort-on-container-exit --exit-code-from system-e2e system-e2e
@@ -65,8 +66,9 @@ docker compose -f e2e/compose.phase3.yml down -v
 
 ## Phase 4 GPU E2E
 
-Builds `mlx-backend` and `cv-backend` from `../../mlops-cloud-backend/Dockerfile.gpu`, seeds one video plus a SAM2 bbox annotation, runs the real `samurai-ulr` inference pipeline, and verifies:
+Builds `mlx-backend` and `cv-backend` from `../../mlops-cloud-backend/Dockerfile.gpu`, starts GPU-enabled `hm-backend`, seeds one video plus a SAM2 bbox annotation, runs the real `samurai-ulr` inference pipeline, and verifies:
 
+- CPU and GPU hardware metrics are recorded in `hardware_metric`
 - `inference_job.status` reaches `Completed`
 - major progress steps complete
 - inference result video and parquet artifacts are registered in DB and exist in S3

--- a/e2e/compose.phase3.yml
+++ b/e2e/compose.phase3.yml
@@ -1,3 +1,10 @@
+x-surreal-env: &surreal-env
+  SURREAL_URL: ws://database:8000/rpc
+  SURREAL_NS: mlops_phase3
+  SURREAL_DB: cloud_ui
+  SURREAL_USER: root
+  SURREAL_PASS: root
+
 services:
   object-storage:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z
@@ -30,16 +37,12 @@ services:
       - database
       - object-storage
     environment:
+      <<: *surreal-env
       NEXT_PUBLIC_SURREAL_URL: ws://database:8000/rpc
       NEXT_PUBLIC_SURREAL_NS: mlops_phase3
       NEXT_PUBLIC_SURREAL_DB: cloud_ui
       NEXT_PUBLIC_SURREAL_USER: root
       NEXT_PUBLIC_SURREAL_PASS: root
-      SURREAL_URL: ws://database:8000/rpc
-      SURREAL_NS: mlops_phase3
-      SURREAL_DB: cloud_ui
-      SURREAL_USER: root
-      SURREAL_PASS: root
       MINIO_ENDPOINT_INTERNAL: http://object-storage:9000
       MINIO_REGION: us-east-1
       MINIO_ACCESS_KEY_ID: minioadmin
@@ -51,6 +54,19 @@ services:
       - "3000:3000"
     restart: unless-stopped
 
+  hm-backend:
+    image: mlops-cloud-backend-base:phase3
+    pull_policy: build
+    build:
+      context: ../../mlops-cloud-backend
+      dockerfile: Dockerfile.base
+    depends_on:
+      - database
+    environment:
+      <<: *surreal-env
+    command: ["uv", "run", "/app/hardware_metrics_manager.py"]
+    restart: unless-stopped
+
   system-e2e:
     image: mlops-cloud-e2e:phase3
     pull_policy: build
@@ -59,9 +75,11 @@ services:
       dockerfile: Dockerfile
     depends_on:
       - cloud-ui
+      - hm-backend
       - database
       - object-storage
     environment:
+      <<: *surreal-env
       BASE_URL: http://cloud-ui:3000
       CI: "1"
     command: ["npx", "playwright", "test", "tests/system.spec.ts"]

--- a/e2e/compose.phase4.yml
+++ b/e2e/compose.phase4.yml
@@ -23,6 +23,10 @@ x-build-gpu: &build-gpu
   context: ../../mlops-cloud-backend
   dockerfile: Dockerfile.gpu
 
+x-build-base: &build-base
+  context: ../../mlops-cloud-backend
+  dockerfile: Dockerfile.base
+
 services:
   object-storage:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z
@@ -99,6 +103,20 @@ services:
     command: ["uv", "run", "/workspace/src/video_manager.py"]
     restart: unless-stopped
 
+  hm-backend:
+    image: mlops-cloud-backend-base:phase4
+    pull_policy: build
+    build: *build-base
+    gpus: all
+    depends_on:
+      - database
+    environment:
+      <<: *surreal-env
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: utility
+    command: ["uv", "run", "/app/hardware_metrics_manager.py"]
+    restart: unless-stopped
+
   phase4-test:
     image: mlops-cloud-backend-base:phase4-test
     pull_policy: build
@@ -109,6 +127,7 @@ services:
       - cloud-ui
       - mlx-backend
       - cv-backend
+      - hm-backend
       - database
       - object-storage
     environment:

--- a/e2e/lib/db.ts
+++ b/e2e/lib/db.ts
@@ -47,7 +47,7 @@ export async function queryRows<T = any>(sql: string, vars?: Record<string, unkn
 
 export async function resetDb(): Promise<void> {
   await withDb(async (client) => {
-    for (const table of ["annotation", "label", "inference_job", "training_job", "hls_job", "hls_playlist", "hls_segment", "merge_group", "file"]) {
+    for (const table of ["annotation", "label", "inference_job", "training_job", "hls_job", "hls_playlist", "hls_segment", "merge_group", "hardware_metric", "file"]) {
       await client.query(`DELETE ${table}`);
     }
   });

--- a/e2e/phase2/conftest.py
+++ b/e2e/phase2/conftest.py
@@ -18,6 +18,7 @@ TABLES = [
     "hls_job",
     "hls_playlist",
     "hls_segment",
+    "hardware_metric",
     "inference_result",
     "inference_job",
     "label",

--- a/e2e/phase2/test_hardware_metrics.py
+++ b/e2e/phase2/test_hardware_metrics.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+
+import hardware_metrics_manager as hm
+from hardware_metrics_manager import HardwareMetricsManager
+from query.utils import extract_results
+
+
+def test_hardware_metric_insert_persists_cpu_and_gpu_shape(db):
+    manager = HardwareMetricsManager(db, cleanup_interval_sec=999)
+    manager._insert_metrics(
+        {
+            "cpu_percent": 12.5,
+            "memory": {
+                "total": 100,
+                "available": 70,
+                "used": 30,
+                "free": 65,
+                "percent": 30.0,
+            },
+            "load_average": [0.1, 0.2, 0.3],
+        },
+        [
+            {
+                "index": 0,
+                "name": "Fake GPU",
+                "utilization": {"gpu_percent": 45, "memory_percent": 20},
+                "memory": {"total": 1000, "used": 200, "free": 800},
+                "power_watts": 77.5,
+                "temperature_c": 55,
+                "fan_speed_percent": 40,
+                "pcie": {"tx_kb_s": 10, "rx_kb_s": 20},
+                "clocks_mhz": {"sm": 1500, "mem": 5000},
+            }
+        ],
+    )
+
+    rows = extract_results(db.query("SELECT * FROM hardware_metric;"))
+
+    assert len(rows) == 1
+    assert rows[0]["system"]["cpu_percent"] == 12.5
+    assert rows[0]["system"]["memory"]["total"] == 100
+    assert rows[0]["gpus"][0]["name"] == "Fake GPU"
+    assert rows[0]["gpus"][0]["memory"]["total"] == 1000
+
+
+def test_gather_system_metrics_contains_cpu_and_memory():
+    metrics = hm._gather_system_metrics()
+
+    assert isinstance(metrics["cpu_percent"], (int, float))
+    assert metrics["cpu_percent"] >= 0
+    assert metrics["memory"]["total"] > 0
+
+
+def test_gather_gpu_metrics_collects_nvml_shape(monkeypatch):
+    class FakeNvml:
+        NVML_TEMPERATURE_GPU = 0
+        NVML_PCIE_UTIL_TX_BYTES = 1
+        NVML_PCIE_UTIL_RX_BYTES = 2
+        NVML_CLOCK_SM = 3
+        NVML_CLOCK_MEM = 4
+
+        def nvmlInit(self):
+            return None
+
+        def nvmlShutdown(self):
+            return None
+
+        def nvmlDeviceGetCount(self):
+            return 1
+
+        def nvmlDeviceGetHandleByIndex(self, index):
+            return f"gpu-{index}"
+
+        def nvmlDeviceGetName(self, handle):
+            return b"Fake NVML GPU"
+
+        def nvmlDeviceGetUtilizationRates(self, handle):
+            return SimpleNamespace(gpu=50, memory=25)
+
+        def nvmlDeviceGetMemoryInfo(self, handle):
+            return SimpleNamespace(total=1000, used=250, free=750)
+
+        def nvmlDeviceGetTemperature(self, handle, sensor):
+            return 60
+
+        def nvmlDeviceGetFanSpeed(self, handle):
+            return 35
+
+        def nvmlDeviceGetPowerUsage(self, handle):
+            return 80000
+
+        def nvmlDeviceGetPcieThroughput(self, handle, counter):
+            return 123
+
+        def nvmlDeviceGetClockInfo(self, handle, clock):
+            return 1500 if clock == self.NVML_CLOCK_SM else 5000
+
+    monkeypatch.setattr(hm, "pynvml", FakeNvml())
+
+    gpus = hm._gather_gpu_metrics()
+
+    assert len(gpus) == 1
+    assert gpus[0]["name"] == "Fake NVML GPU"
+    assert gpus[0]["utilization"]["gpu_percent"] == 50
+    assert gpus[0]["memory"]["total"] == 1000
+    assert gpus[0]["power_watts"] == 80.0

--- a/e2e/phase4/conftest.py
+++ b/e2e/phase4/conftest.py
@@ -21,6 +21,7 @@ TABLES = [
     "hls_segment",
     "inference_result",
     "inference_job",
+    "hardware_metric",
     "label",
     "merge_group",
     "file",

--- a/e2e/phase4/test_hardware_metrics_gpu.py
+++ b/e2e/phase4/test_hardware_metrics_gpu.py
@@ -1,0 +1,42 @@
+import time
+
+from query.utils import extract_results
+
+
+def _rows(db, sql: str, vars=None):
+    return extract_results(db.query(sql, vars or {}))
+
+
+def _wait_for(predicate, *, timeout: int, interval: int = 2, label: str):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(interval)
+    raise AssertionError(f"Timed out waiting for {label}; last={last!r}")
+
+
+def test_hardware_metrics_records_cpu_and_gpu(db):
+    def observed_metrics():
+        rows = _rows(db, "SELECT * FROM hardware_metric ORDER BY ts DESC LIMIT 20;")
+        cpu_rows = [
+            row for row in rows
+            if isinstance((row.get("system") or {}).get("cpu_percent"), (int, float))
+            and ((row.get("system") or {}).get("memory") or {}).get("total", 0) > 0
+        ]
+        gpu_rows = [
+            row for row in rows
+            if any(
+                gpu.get("name")
+                and ((gpu.get("memory") or {}).get("total", 0) > 0)
+                for gpu in (row.get("gpus") or [])
+                if isinstance(gpu, dict)
+            )
+        ]
+        return {"cpu": cpu_rows[0], "gpu": gpu_rows[0]} if cpu_rows and gpu_rows else None
+
+    metrics = _wait_for(observed_metrics, timeout=120, label="CPU and GPU hardware metrics")
+    assert metrics["cpu"]["system"]["cpu_percent"] >= 0
+    assert len(metrics["gpu"]["gpus"]) >= 1

--- a/e2e/tests/system.spec.ts
+++ b/e2e/tests/system.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { waitForHealthyApp } from "../lib/app";
+import { queryRows } from "../lib/db";
 
 test("system compose exposes healthy UI and core routes", async ({ request }) => {
   await waitForHealthyApp(request);
@@ -12,4 +13,21 @@ test("system compose exposes healthy UI and core routes", async ({ request }) =>
     const response = await request.get(path);
     await expect(response, `${path} should return HTTP 200`).toBeOK();
   }
+});
+
+test("system compose records CPU hardware metrics", async ({ request }) => {
+  await waitForHealthyApp(request);
+
+  await expect.poll(async () => {
+    const metrics = await queryRows<any>("SELECT * FROM hardware_metric ORDER BY ts DESC LIMIT 10;");
+    return metrics.filter((row) => {
+      const system = row?.system;
+      return typeof system?.cpu_percent === "number"
+        && typeof system?.memory?.total === "number"
+        && system.memory.total > 0;
+    }).length;
+  }, {
+    timeout: 60_000,
+    intervals: [1_000, 2_000, 5_000],
+  }).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- Add E2E coverage for hardware metrics across Phase2, Phase3, and Phase4.
- Give the dev `hm-backend` GPU device access under the `gpu` profile so GPU metrics are visible when ML containers can use GPU.
- Document CPU/GPU hardware metrics checks in the E2E docs.

## Root Cause
`hm-backend` did not request GPU devices in dev/GPU compose, so NVML could not see GPUs even though ML/CV containers could. Existing E2E coverage also did not assert CPU or GPU hardware metrics persistence.

## Validation
- `docker compose -f docker-compose.dev.yml config`
- `docker compose -f docker-compose.dev.yml --profile gpu config`
- `docker compose -f e2e/compose.phase1.yml up --build --abort-on-container-exit --exit-code-from e2e e2e` -> 7 passed, 3 skipped
- `docker compose -f e2e/compose.phase2.yml up --build --abort-on-container-exit --exit-code-from backend-test backend-test` -> 18 passed
- `docker compose -f e2e/compose.phase3.yml up --build --abort-on-container-exit --exit-code-from system-e2e system-e2e` -> 2 passed
- Phase4 targeted GPU hardware metrics -> 1 passed
- `docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test` -> 2 passed
- `git diff --check`
