### PR TITLE
[codex] Test inference log persistence

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -54,6 +54,8 @@ Covered areas:
 - cleaner dead-file and orphan-annotation DB/S3 cleanup
 - inference runner validation for zero, multiple, no-video, multiple-video, and valid single-video dataset inputs
 - hardware metric CPU/GPU record shape, including a mocked NVML GPU
+- inference job log persistence and per-job filtering
+- inference job log archival to S3 `.log` files in fixed-size chunks while keeping only the DB tail
 
 ## Phase 3 System E2E
 
@@ -69,6 +71,8 @@ docker compose -f e2e/compose.phase3.yml down -v
 Builds `mlx-backend` and `cv-backend` from `../../mlops-cloud-backend/Dockerfile.gpu`, starts GPU-enabled `hm-backend`, seeds one video plus a SAM2 bbox annotation, runs the real `samurai-ulr` inference pipeline, and verifies:
 
 - CPU and GPU hardware metrics are recorded in `hardware_metric`
+- MLX/CV console output is persisted in `inference_job_log` and scoped to the running inference job
+- long-running logs can be archived as `inference_job_log_archive` `.log` chunks in S3
 - `inference_job.status` reaches `Completed`
 - major progress steps complete
 - inference result video and parquet artifacts are registered in DB and exist in S3

--- a/e2e/lib/db.ts
+++ b/e2e/lib/db.ts
@@ -47,7 +47,7 @@ export async function queryRows<T = any>(sql: string, vars?: Record<string, unkn
 
 export async function resetDb(): Promise<void> {
   await withDb(async (client) => {
-    for (const table of ["annotation", "label", "inference_job", "training_job", "hls_job", "hls_playlist", "hls_segment", "merge_group", "hardware_metric", "file"]) {
+    for (const table of ["annotation", "label", "inference_job_log_archive", "inference_job_log", "inference_job", "training_job", "hls_job", "hls_playlist", "hls_segment", "merge_group", "hardware_metric", "file"]) {
       await client.query(`DELETE ${table}`);
     }
   });

--- a/e2e/phase2/conftest.py
+++ b/e2e/phase2/conftest.py
@@ -20,6 +20,8 @@ TABLES = [
     "hls_segment",
     "hardware_metric",
     "inference_result",
+    "inference_job_log_archive",
+    "inference_job_log",
     "inference_job",
     "label",
     "merge_group",

--- a/e2e/phase2/test_inference_job_logs.py
+++ b/e2e/phase2/test_inference_job_logs.py
@@ -1,0 +1,172 @@
+from backend_module.job_log import capture_job_logs
+from query.inference_job_log_query import append_job_log, count_job_logs, list_job_log_archives, list_job_logs
+from query.utils import first_result
+
+
+def _created_id(payload) -> str:
+    row = first_result(payload)
+    assert row and row.get("id")
+    return str(row["id"])
+
+
+def test_inference_job_logs_are_scoped_by_job(db):
+    job_a = _created_id(
+        db.query(
+            """
+            CREATE inference_job CONTENT {
+                name: 'log-job-a',
+                dead: false,
+                status: 'ProcessRunning',
+                taskType: 'one-shot-object-detection',
+                model: 'fake',
+                modelSource: 'internet',
+                datasets: ['ds-a'],
+                createdAt: time::now(),
+                updatedAt: time::now()
+            };
+            """
+        )
+    )
+    job_b = _created_id(
+        db.query(
+            """
+            CREATE inference_job CONTENT {
+                name: 'log-job-b',
+                dead: false,
+                status: 'ProcessRunning',
+                taskType: 'one-shot-object-detection',
+                model: 'fake',
+                modelSource: 'internet',
+                datasets: ['ds-b'],
+                createdAt: time::now(),
+                updatedAt: time::now()
+            };
+            """
+        )
+    )
+
+    append_job_log(db, job_id=job_a, source="mlx", stream="stdout", message="job-a line", seq=1)
+    append_job_log(db, job_id=job_b, source="mlx", stream="stdout", message="job-b line", seq=1)
+
+    logs = list_job_logs(db, job_id=job_a)
+    assert [line["message"] for line in logs] == ["job-a line"]
+
+
+def test_capture_job_logs_persists_stdout_and_stderr(db):
+    job_id = _created_id(
+        db.query(
+            """
+            CREATE inference_job CONTENT {
+                name: 'captured-log-job',
+                dead: false,
+                status: 'ProcessRunning',
+                taskType: 'one-shot-object-detection',
+                model: 'fake',
+                modelSource: 'internet',
+                datasets: ['ds-a'],
+                createdAt: time::now(),
+                updatedAt: time::now()
+            };
+            """
+        )
+    )
+
+    with capture_job_logs(db, job_id=job_id, source="mlx"):
+        print("stdout line")
+        import sys
+        print("stderr line", file=sys.stderr)
+
+    logs = list_job_logs(db, job_id=job_id)
+    assert [(line["source"], line["stream"], line["message"]) for line in logs] == [
+        ("mlx", "stdout", "stdout line"),
+        ("mlx", "stderr", "stderr line"),
+    ]
+
+
+def test_inference_job_logs_return_more_than_legacy_ui_cap(db):
+    job_id = _created_id(
+        db.query(
+            """
+            CREATE inference_job CONTENT {
+                name: 'large-log-job',
+                dead: false,
+                status: 'ProcessRunning',
+                taskType: 'one-shot-object-detection',
+                model: 'fake',
+                modelSource: 'internet',
+                datasets: ['ds-a'],
+                createdAt: time::now(),
+                updatedAt: time::now()
+            };
+            """
+        )
+    )
+
+    for index in range(600):
+        append_job_log(
+            db,
+            job_id=job_id,
+            source="mlx",
+            stream="stdout",
+            message=f"line-{index}",
+            seq=index,
+        )
+
+    logs = list_job_logs(db, job_id=job_id)
+    assert len(logs) == 600
+    assert logs[0]["message"] == "line-0"
+    assert logs[-1]["message"] == "line-599"
+
+
+def test_inference_job_logs_archive_to_s3_in_chunks_and_keep_db_tail(db, s3, tmp_path):
+    job_id = _created_id(
+        db.query(
+            """
+            CREATE inference_job CONTENT {
+                name: 'archived-log-job',
+                dead: false,
+                status: 'ProcessRunning',
+                taskType: 'one-shot-object-detection',
+                model: 'fake',
+                modelSource: 'internet',
+                datasets: ['ds-a'],
+                createdAt: time::now(),
+                updatedAt: time::now()
+            };
+            """
+        )
+    )
+
+    for index in range(25):
+        append_job_log(
+            db,
+            job_id=job_id,
+            source="mlx",
+            stream="stdout",
+            message=f"line-{index}",
+            seq=index,
+            archive_uploader=s3,
+            retention=10,
+            archive_chunk_size=10,
+        )
+
+    assert count_job_logs(db, job_id=job_id) == 5
+    assert [row["message"] for row in list_job_logs(db, job_id=job_id)] == [f"line-{i}" for i in range(20, 25)]
+
+    archives = list_job_log_archives(db, job_id=job_id)
+    assert len(archives) == 2
+    assert [archive["rowCount"] for archive in archives] == [10, 10]
+
+    restored_lines = []
+    for index, archive in enumerate(archives):
+        assert archive["key"].endswith(".log")
+        local_path = tmp_path / f"archive-{index}.log"
+        downloaded = s3.download_file(archive["key"], str(local_path))
+        assert downloaded.local_path == str(local_path)
+        restored_lines.extend(local_path.read_text(encoding="utf-8").splitlines())
+
+    assert len(restored_lines) == 20
+    for index, line in enumerate(restored_lines):
+        assert f"[# {index}]" not in line
+        assert f"[#{index}]" in line
+        assert f"line-{index}" in line

--- a/e2e/phase4/conftest.py
+++ b/e2e/phase4/conftest.py
@@ -20,6 +20,8 @@ TABLES = [
     "hls_playlist",
     "hls_segment",
     "inference_result",
+    "inference_job_log_archive",
+    "inference_job_log",
     "inference_job",
     "hardware_metric",
     "label",

--- a/e2e/phase4/test_gpu_samurai_pipeline.py
+++ b/e2e/phase4/test_gpu_samurai_pipeline.py
@@ -135,6 +135,14 @@ def test_real_samurai_ulr_gpu_pipeline_to_hls_and_ui(db, s3, fixture_video: Path
     for row in [*hls["playlists"], *hls["segments"]]:
         assert object_exists(s3, row["key"]) is True
 
+    logs = _rows(
+        db,
+        "SELECT source, stream, message, createdAt, seq FROM inference_job_log WHERE job = <record> $JOB ORDER BY createdAt ASC, seq ASC;",
+        {"JOB": job_id},
+    )
+    assert any(row.get("source") == "mlx" and "started" in str(row.get("message", "")) for row in logs)
+    assert any(row.get("source") == "cv" and "hls_job" in str(row.get("message", "")) for row in logs)
+
     base_url = os.getenv("BASE_URL", "http://cloud-ui:3000")
     for path in ["/api/status", "/inference/opened-job", "/inference/opened-job/analysis"]:
         response = requests.get(f"{base_url}{path}", timeout=30)


### PR DESCRIPTION
## Summary

- Add Phase2 backend tests for inference job log scoping, stdout/stderr capture, >500-line retrieval, and S3 `.log` archival.
- Reset `inference_job_log_archive` in E2E cleanup.
- Extend Phase4 expectations to verify MLX/CV job logs are persisted.
- Document log persistence and archival coverage in the E2E README.

## Impact

The E2E suite now validates the log persistence contract and the DB-tail plus S3-archive behavior.

## Validation

- `docker compose -f e2e/compose.phase2.yml -f /tmp/phase2-no-ports.yml up --build --abort-on-container-exit --exit-code-from backend-test backend-test`: `22 passed`
- `docker compose -f e2e/compose.phase1.yml -f /tmp/phase1-no-ports.yml up --build --abort-on-container-exit --exit-code-from e2e e2e`: `7 passed, 3 skipped`
- `git diff --check`