### PR TITLE
[codex] Add T260 ULR E2E coverage

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,7 +20,7 @@ docker compose -f e2e/compose.phase1.yml up --build --abort-on-container-exit --
 docker compose -f e2e/compose.phase1.yml down -v
 ```
 
-Current expected result: `7 passed, 3 skipped`.
+Current expected result: `8 passed, 3 skipped`.
 
 Executed tests include:
 
@@ -68,7 +68,7 @@ docker compose -f e2e/compose.phase3.yml down -v
 
 ## Phase 4 GPU E2E
 
-Builds `mlx-backend` and `cv-backend` from `../../mlops-cloud-backend/Dockerfile.gpu`, starts GPU-enabled `hm-backend`, seeds one video plus a SAM2 bbox annotation, runs the real `samurai-ulr` inference pipeline, and verifies:
+Builds `mlx-backend` and `cv-backend` from `../../mlops-cloud-backend/Dockerfile.gpu`, starts GPU-enabled `hm-backend`, seeds one video plus a SAM2 bbox annotation, runs the real `samurai-ulr` inference pipeline by default, and verifies:
 
 - CPU and GPU hardware metrics are recorded in `hardware_metric`
 - MLX/CV console output is persisted in `inference_job_log` and scoped to the running inference job
@@ -92,6 +92,7 @@ Optional overrides:
 ```bash
 PHASE4_TIMEOUT_SECONDS=7200 docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test
 PHASE4_REQUIRE_SCHEMA_JSON=1 docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test
+PHASE4_MODEL=t260-ulr PHASE4_RTDETR_EPOCHS=1 T260_RFDETR_VARIANT=nano docker compose -f e2e/compose.phase4.yml up --build --abort-on-container-exit --exit-code-from phase4-test phase4-test
 ```
 
 ## Cleanup

--- a/e2e/compose.phase1.yml
+++ b/e2e/compose.phase1.yml
@@ -7,17 +7,12 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     tmpfs:
       - /data
-    ports:
-      - "9000:9000"
-      - "9001:9001"
     restart: unless-stopped
 
   database:
     image: surrealdb/surrealdb:v2.3
     user: "0:0"
     command: start --user root --pass root memory
-    ports:
-      - "8000:8000"
     restart: unless-stopped
 
   cloud-ui:
@@ -47,8 +42,6 @@ services:
       MINIO_BUCKET: mlops-e2e
       MINIO_FORCE_PATH_STYLE: "true"
       S3_MULTIPART_THRESHOLD_BYTES: "1000000000"
-    ports:
-      - "3000:3000"
     restart: unless-stopped
 
   e2e:

--- a/e2e/compose.phase2.yml
+++ b/e2e/compose.phase2.yml
@@ -7,17 +7,12 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     tmpfs:
       - /data
-    ports:
-      - "9000:9000"
-      - "9001:9001"
     restart: unless-stopped
 
   database:
     image: surrealdb/surrealdb:v2.3
     user: "0:0"
     command: start --user root --pass root memory
-    ports:
-      - "8000:8000"
     restart: unless-stopped
 
   backend-test:

--- a/e2e/compose.phase3.yml
+++ b/e2e/compose.phase3.yml
@@ -14,17 +14,12 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     tmpfs:
       - /data
-    ports:
-      - "9000:9000"
-      - "9001:9001"
     restart: unless-stopped
 
   database:
     image: surrealdb/surrealdb:v2.3
     user: "0:0"
     command: start --user root --pass root memory
-    ports:
-      - "8000:8000"
     restart: unless-stopped
 
   cloud-ui:
@@ -50,8 +45,6 @@ services:
       MINIO_BUCKET: mlops-phase3
       MINIO_FORCE_PATH_STYLE: "true"
       S3_MULTIPART_THRESHOLD_BYTES: "1000000000"
-    ports:
-      - "3000:3000"
     restart: unless-stopped
 
   hm-backend:

--- a/e2e/compose.phase4.yml
+++ b/e2e/compose.phase4.yml
@@ -18,6 +18,9 @@ x-backend-env: &backend-env
   <<: [*surreal-env, *s3-env]
   POLL_INTERVAL: "5"
   KEEP_WORK_DIR: "0"
+  T260_RFDETR_VARIANT: ${T260_RFDETR_VARIANT:-nano}
+  T260_RFDETR_BATCH_SIZE: ${T260_RFDETR_BATCH_SIZE:-1}
+  T260_RFDETR_GRAD_ACCUM_STEPS: ${T260_RFDETR_GRAD_ACCUM_STEPS:-1}
 
 x-build-gpu: &build-gpu
   context: ../../mlops-cloud-backend
@@ -36,17 +39,12 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     tmpfs:
       - /data
-    ports:
-      - "9000:9000"
-      - "9001:9001"
     restart: unless-stopped
 
   database:
     image: surrealdb/surrealdb:v2.3
     user: "0:0"
     command: start --user root --pass root memory
-    ports:
-      - "8000:8000"
     restart: unless-stopped
 
   cloud-ui:
@@ -65,8 +63,6 @@ services:
       NEXT_PUBLIC_SURREAL_DB: cloud_gpu
       NEXT_PUBLIC_SURREAL_USER: root
       NEXT_PUBLIC_SURREAL_PASS: root
-    ports:
-      - "3000:3000"
     restart: unless-stopped
 
   mlx-backend:
@@ -135,6 +131,8 @@ services:
       BASE_URL: http://cloud-ui:3000
       PHASE4_TIMEOUT_SECONDS: "3600"
       PHASE4_REQUIRE_SCHEMA_JSON: "0"
+      PHASE4_MODEL: ${PHASE4_MODEL:-samurai-ulr}
+      PHASE4_RTDETR_EPOCHS: ${PHASE4_RTDETR_EPOCHS:-1}
     volumes:
       - ./phase4:/app/tests_phase4:ro
       - ./fixtures:/fixtures:ro

--- a/e2e/phase4/test_gpu_samurai_pipeline.py
+++ b/e2e/phase4/test_gpu_samurai_pipeline.py
@@ -34,6 +34,9 @@ def _wait_for(predicate, *, timeout: int, interval: int = 10, label: str):
 def test_real_samurai_ulr_gpu_pipeline_to_hls_and_ui(db, s3, fixture_video: Path):
     timeout = int(os.getenv("PHASE4_TIMEOUT_SECONDS", "3600"))
     require_schema_json = os.getenv("PHASE4_REQUIRE_SCHEMA_JSON", "0").lower() in {"1", "true", "yes", "on"}
+    model = os.getenv("PHASE4_MODEL", "samurai-ulr")
+    assert model in {"samurai-ulr", "t260-ulr"}
+    epochs = int(os.getenv("PHASE4_RTDETR_EPOCHS", "1"))
     dataset = f"phase4-gpu-{int(time.time())}"
     video_key = f"{dataset}/input/test-video.mp4"
 
@@ -91,14 +94,16 @@ def test_real_samurai_ulr_gpu_pipeline_to_hls_and_ui(db, s3, fixture_video: Path
                 dead: false,
                 status: 'ProcessWaiting',
                 taskType: 'one-shot-object-detection',
-                model: 'samurai-ulr',
+                model: $MODEL,
                 modelSource: 'internet',
+                inferenceBackend: 'pytorch-fp16',
+                rtdetrEpochs: $EPOCHS,
                 datasets: [$DATASET],
                 createdAt: time::now(),
                 updatedAt: time::now()
             };
             """,
-            {"NAME": f"phase4-samurai-{int(time.time())}", "DATASET": dataset},
+            {"NAME": f"phase4-{model}-{int(time.time())}", "MODEL": model, "EPOCHS": epochs, "DATASET": dataset},
         )
     )
 
@@ -108,7 +113,7 @@ def test_real_samurai_ulr_gpu_pipeline_to_hls_and_ui(db, s3, fixture_video: Path
             raise AssertionError(f"GPU inference job failed early: {row}")
         return row if row and row.get("status") == "Completed" else None
 
-    job = _wait_for(completed_job, timeout=timeout, interval=15, label="samurai inference completion")
+    job = _wait_for(completed_job, timeout=timeout, interval=15, label=f"{model} inference completion")
     assert job["status"] == "Completed"
     steps = {s.get("key"): s.get("state") for s in (job.get("progress") or {}).get("steps", []) if isinstance(s, dict)}
     for key in ["download", "preprocess", "sam2", "dataset_export", "rtdetr_train", "rtdetr_infer", "postprocess", "upload"]:

--- a/e2e/tests/inference.spec.ts
+++ b/e2e/tests/inference.spec.ts
@@ -47,6 +47,43 @@ test("creates an inference job from a seeded video dataset", async ({ page }) =>
   });
 });
 
+test("creates a T260 ULR inference job from a seeded video dataset", async ({ page }) => {
+  const dataset = uniqueName("e2e-video");
+  const jobName = uniqueName("e2e-t260-inference");
+  const fileName = videoFixture.name;
+  const key = `${dataset}/${fileName}`;
+
+  await putObject(key, videoFixture.buffer, videoFixture.mimeType);
+  await queryRows(
+    "CREATE file CONTENT { dataset: $dataset, name: $name, key: $key, bucket: $bucket, mime: $mime, size: $size, encode: 'video-none', uploadedAt: time::now() }",
+    { dataset, name: fileName, key, bucket: env.s3.bucket, mime: videoFixture.mimeType, size: videoFixture.buffer.byteLength },
+  );
+
+  await page.goto("/inference/create");
+  await page.getByPlaceholder("my-inference-job").fill(jobName);
+  await page.getByLabel(dataset).check({ force: true });
+
+  await page.getByRole("combobox").nth(0).click();
+  await page.getByRole("option", { name: "One Shot Object Detection" }).click();
+  await page.getByRole("combobox").nth(1).click();
+  await page.getByRole("option", { name: /T260 ULR/i }).click();
+
+  await page.getByRole("button", { name: "Start" }).click();
+  await expect(page).toHaveURL(/\/inference\/opened-job/);
+
+  const rows = await queryRows<any>("SELECT * FROM inference_job WHERE name == $name", { name: jobName });
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toMatchObject({
+    name: jobName,
+    status: "ProcessWaiting",
+    taskType: "one-shot-object-detection",
+    model: "t260-ulr",
+    modelSource: "internet",
+    inferenceBackend: "pytorch-fp16",
+    datasets: [dataset],
+  });
+});
+
 test.fixme("inference creation rejects multiple selected datasets with a visible reason", async () => {
   // Product behavior is still permissive. Enable this once the UI validation is implemented.
 });


### PR DESCRIPTION
## Summary

Adds compose and E2E support for validating T260-ULR through the integration repository.

- Adds a Phase1 Playwright test that creates a `t260-ulr` inference job from the UI.
- Makes Phase4 GPU E2E switchable via `PHASE4_MODEL=t260-ulr`.
- Adds Phase4 knobs for short RF-DETR validation runs: `PHASE4_RTDETR_EPOCHS`, `T260_RFDETR_VARIANT`, `T260_RFDETR_BATCH_SIZE`, and `T260_RFDETR_GRAD_ACCUM_STEPS`.
- Removes host port publishing from E2E compose files so tests can run while a dev stack already owns ports `3000`, `8000`, and `9000`.
- Updates E2E docs for the new expected Phase1 count and T260 Phase4 command.

## Validation

- Phase1 E2E -> `8 passed, 3 skipped`
- Phase2 E2E -> `22 passed`
- Phase3 E2E -> `2 passed`
- Phase4 GPU E2E with `PHASE4_MODEL=t260-ulr PHASE4_RTDETR_EPOCHS=1 T260_RFDETR_VARIANT=nano T260_RFDETR_BATCH_SIZE=1 T260_RFDETR_GRAD_ACCUM_STEPS=1` -> `2 passed`
- Ran `docker compose ... down -v` after each phase.